### PR TITLE
Linux compatible version. Confirmed working on mac and Windows.

### DIFF
--- a/TSBB11/main.cpp
+++ b/TSBB11/main.cpp
@@ -10,15 +10,29 @@
 // * Use glUniform1fv instead of glUniform1f, since glUniform1f has a bug under Linux.
 
 #ifdef __APPLE__
-#include <OpenGL/gl3.h>
-// Uses framework Cocoa.
+	#include <OpenGL/gl3.h>
+	#include <SDL2/SDL.h>
+#else
+	#ifdef  __linux__
+		#define GL_GLEXT_PROTOTYPES
+		#include <GL/gl.h>
+		#include <GL/glu.h>
+		#include <GL/glx.h>
+		#include <GL/glext.h>
+		#include <SDL2/SDL.h>
+		
+		
+	#else
+		#include "glew.h"
+		#include "Windows/sdl2/SDL.h"
+	#endif
 #endif
+
 #include <cstdlib>
 #include <iostream>
 #include "GL_utilities.h"
 #include "loadobj.h"
 #include "LoadTGA.h"
-#include "sdl2/SDL.h"
 #include "glm.hpp"
 #include "gtc/matrix_transform.hpp"
 #include "gtc/type_ptr.hpp"

--- a/TSBB11/makefile
+++ b/TSBB11/makefile
@@ -1,3 +1,9 @@
+ifeq ($(shell uname), Darwin)
+	PLATFORM=mac
+endif
+ifeq ($(shell uname), Linux)
+	PLATFORM=linux
+endif
 $SOURCEDIR = src
 
 CPP_FILES := $(wildcard src/*.cpp)
@@ -8,15 +14,24 @@ C_FILES_COMMON := $(wildcard src/common/*.c)
 
 OBJ_FILES_COMMON := $(addprefix obj/,$(notdir $(C_FILES_COMMON:.c=.o)))
 
-INC = -Isrc/ -Isrc/common/ -Isrc/common/glm -F/Library/Frameworks/
+INC = -Isrc/ -Isrc/common/ -Isrc/common/glm
 MAIN = main.cpp
 OUT = bin/WaterFlow
 
-#if MAC
+ifeq ($(PLATFORM),mac)
+INC += -F/Library/Frameworks/
 LINKS =  -framework OpenGL -framework GLUT -framework Cocoa -framework SDL2
+endif
 
 GCC = g++ -Wall -pedantic -std=c++0x
-CC = gcc
+
+#if Linux
+ifeq ($(PLATFORM),linux)
+INC += $(shell pkg-config --cflags sdl2)
+LINKS = $(shell pkg-config --libs sdl2)
+LINKS += -lGL -lglut -lm -lXt -lX11 
+GCC += -std=gnu++0x
+endif
 
 all: $(OBJ_FILES_COMMON) $(OBJ_FILES_CPP)
 	$(GCC) obj/*.o $(MAIN) -o $(OUT) $(INC) $(LINKS)

--- a/TSBB11/src/camera.cpp
+++ b/TSBB11/src/camera.cpp
@@ -7,6 +7,11 @@
 
 Camera::Camera(int program, glm::mat4 *matrix)
 {
+
+    position = glm::vec3( 23.5 * 6, 2.5 * 6, 28 * 6 );
+    x = 0; 
+    look_at_pos = glm::vec3( 23.5 * 6, 2.5 * 6, 28 * 5 );
+    up = glm::vec3(0,1,0);
     this->matrix = matrix;
     this->program = program;
     *matrix = glm::lookAt(position, look_at_pos, up);

--- a/TSBB11/src/camera.h
+++ b/TSBB11/src/camera.h
@@ -3,13 +3,20 @@
 
 #ifdef __APPLE__
 	#include <OpenGL/gl3.h>
-  #include <GLUT/glut.h>
-	//#include "MicroGlut.h"
+	#include <GLUT/glut.h>
 #else
-	//#include "MicroGlut.h"
-	//#include <GL/gl.h>
-  #include "glew.h"
+	#ifdef  __linux__
+		#define GL_GLEXT_PROTOTYPES
+		#include <GL/gl.h>
+		#include <GL/glu.h>
+		#include <GL/glx.h>
+		#include <GL/glext.h>
+		
+	#else
+		#include "glew.h"
+	#endif
 #endif
+
 
 #ifndef M_PI
 #define M_PI           3.14159265358979323846f
@@ -25,15 +32,15 @@ class Camera {
     private:
         // x används för att musen inte ska fastna i kanterna på
         // fönstret
-        int x{0};
+        int x;
         int program;
     public:
         Camera(int program, glm::mat4 *matrix);
         Camera();
 
-		glm::vec3 position{ 23.5 * 6, 2.5 * 6, 28 * 6 };
-		glm::vec3 look_at_pos{ 23.5 * 6, 2.5 * 6, 28 * 5 };
-        glm::vec3 up{0,1,0};
+	glm::vec3 position;
+	glm::vec3 look_at_pos;
+        glm::vec3 up;
 
         glm::mat4 *matrix;
 

--- a/TSBB11/src/common/GL_utilities.h
+++ b/TSBB11/src/common/GL_utilities.h
@@ -9,7 +9,16 @@ extern "C" {
 	#include <OpenGL/gl3.h>
 	#include <GLUT/glut.h>
 #else
-	#include "glew.h"
+	#ifdef  __linux__
+		#define GL_GLEXT_PROTOTYPES
+		#include <GL/gl.h>
+		#include <GL/glu.h>
+		#include <GL/glx.h>
+		#include <GL/glext.h>
+		
+	#else
+		#include "glew.h"
+	#endif
 #endif
 
 void printError(const char *functionName);

--- a/TSBB11/src/common/LoadTGA.h
+++ b/TSBB11/src/common/LoadTGA.h
@@ -8,10 +8,16 @@ extern "C" {
 #ifdef __APPLE__
 	#include <OpenGL/gl3.h>
 #else
-	#if defined(_WIN32)
+	#ifdef  __linux__
+		#define GL_GLEXT_PROTOTYPES
+		#include <GL/gl.h>
+		#include <GL/glu.h>
+		#include <GL/glx.h>
+		#include <GL/glext.h>
+		
+	#else
 		#include "glew.h"
 	#endif
-	//#include <GL/gl.h>
 #endif
 #include <stdio.h>
 #include <stdlib.h>

--- a/TSBB11/src/common/SDL_util.h
+++ b/TSBB11/src/common/SDL_util.h
@@ -9,10 +9,20 @@ extern "C" {
 	#include <OpenGL/gl3.h>
 	#include <SDL2/SDL.h>
 #else
-	#include "glew.h"
-	#include "Windows/sdl2/SDL.h"
+	#ifdef  __linux__
+		#define GL_GLEXT_PROTOTYPES
+		#include <GL/gl.h>
+		#include <GL/glu.h>
+		#include <GL/glx.h>
+		#include <GL/glext.h>
+		#include <SDL2/SDL.h>
+		
+		
+	#else
+		#include "glew.h"
+		#include "Windows/sdl2/SDL.h"
+	#endif
 #endif
-
 
 /******************************************************************************
  * Koder för egna event, såsom timers och liknande.

--- a/TSBB11/src/common/loadobj.h
+++ b/TSBB11/src/common/loadobj.h
@@ -8,7 +8,14 @@ extern "C" {
 #ifdef __APPLE__
 	#include <OpenGL/gl3.h>
 #else
-	#if defined(_WIN32)
+	#ifdef  __linux__
+		#define GL_GLEXT_PROTOTYPES
+		#include <GL/gl.h>
+		#include <GL/glu.h>
+		#include <GL/glx.h>
+		#include <GL/glext.h>
+		
+	#else
 		#include "glew.h"
 	#endif
 #endif


### PR DESCRIPTION
Note that lab env. runs only experimental c++11 under gcc 4.4.x
i.e. no x{0}, and no nullptr (#define nullptr NULL for quickfix).

Suggested include structure (for os specifics)  for future files: 

```
#ifdef __APPLE__
    #include <OpenGL/gl3.h>
#else
    #ifdef  __linux__
        #define GL_GLEXT_PROTOTYPES
        #include <GL/gl.h>
        #include <GL/glu.h>
        #include <GL/glx.h>
        #include <GL/glext.h>
    #else
        #include "glew.h"
    #endif
#endif

```
